### PR TITLE
Support for Chips-2.0 and fixing small ethernet frames

### DIFF
--- a/source/server.c
+++ b/source/server.c
@@ -11,19 +11,27 @@
 //  A TCP/IP stack that supports a single socket connection.
 //
 ////////////////////////////////////////////////////////////////////////////////
+
+input_eth_rx  =   input ("eth_rx");
+output_eth_tx =   output("eth_tx");
+
+input_socket    =   input ("socket");
+output_socket   =   output("socket");
+
+
 void put_eth(unsigned i){
-	output_eth_tx(i);
+	fputc(i, output_eth_tx);
 }
 void put_socket(unsigned i){
-	output_socket(i);
+	fputc(i,output_socket);
 }
 unsigned get_eth(){
-	return input_eth_rx();
+	return fgetc(input_eth_rx);
 }
 unsigned rdy_eth(){
-	return ready_eth_rx();
+	return ready(input_eth_rx);
 }
 unsigned get_socket(){
-	return input_socket();
+	return fgetc(input_socket);
 }
 #include "server.h"

--- a/source/server.h
+++ b/source/server.h
@@ -163,7 +163,7 @@ unsigned get_ethernet_packet(unsigned packet[]){
 			tx_packet[20] = packet[15]; //
 			put_ethernet_packet(
 				tx_packet, 
-				64,
+				60,
 				packet[11],
 				packet[12],
 				packet[13],
@@ -210,7 +210,7 @@ unsigned get_arp_cache(unsigned ip_hi, unsigned ip_lo){
 	tx_packet[20] = ip_lo; //
 	put_ethernet_packet(
 		tx_packet, 
-		64u,
+		60u,
 		0xffffu, //broadcast via ethernet
 		0xffffu,
 		0xffffu,
@@ -279,10 +279,10 @@ void put_ip_packet(unsigned packet[], unsigned total_length, unsigned protocol, 
 	packet[12] = check_checksum();
 
 	//enforce minimum ethernet frame size
-	if(number_of_bytes < 64){
-		number_of_bytes = 64;
+	if(number_of_bytes < 60){
+		number_of_bytes = 60;
 	}
-
+	
 	//send packet over ethernet
 	put_ethernet_packet(
 		packet,                  //packet
@@ -485,7 +485,7 @@ void application_put_data(unsigned packet[], unsigned start, unsigned length){
 unsigned application_get_data(unsigned packet[], unsigned start){
 	unsigned i, index, length;
 
-	if(!ready_socket()){
+	if(!ready(input_socket)){
 		return 0;
 	}
 
@@ -649,7 +649,7 @@ void server()
 					if(state == last_state) put_tcp_packet(tx_packet, tx_length);
 				}
 
-				if(state == send && ready_socket()){
+				if(state == send && ready(output_socket)){
 					break;
 				}
 

--- a/source/user_design.c
+++ b/source/user_design.c
@@ -12,11 +12,28 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 
+#include <stdio.h>
+
+
+output_leds   	=   output("leds");
+      
+input_switches  =   input ("switches");
+input_buttons   =   input ("buttons");
+      
+input_socket    =   input ("socket");
+output_socket   =   output("socket");
+      
+input_rs232_rx  =   input ("rs232_rx");
+output_rs232_tx =   output("rs232_tx");
+
+module("user_design");
+      
+
 void put_socket(unsigned i){
-	output_socket(i);
+	fputc(i, output_socket);
 }
 void stdout_put_char(unsigned i){
-	output_rs232_tx(i);
+	fputc(i,output_rs232_tx);
 }
 
 #include "print.h"
@@ -33,6 +50,7 @@ int find(unsigned string[], unsigned search, unsigned start, unsigned end){
 	}
 	return -1;
 }
+
 
 void user_design()
 {
@@ -76,10 +94,11 @@ void user_design()
 	print_string("Connect your web browser to 192.168.1.1\n");
 	while(1){
 
-		length = input_socket();
+		length = fgetc(input_socket);
 		index = 0;
-		for(i=0;i<length;i+=2){
-			word = input_socket();
+		for(i=0;i<length;i+=2)
+		{
+			word = fgetc(input_socket);
 			data[index] = (word >> 8) & 0xff;
 			index++;
 			data[index] = (word) & 0xff;
@@ -106,11 +125,11 @@ void user_design()
 			if(find(data, 'F', start, end) != -1) leds |= 32;
 			if(find(data, 'G', start, end) != -1) leds |= 64;
 			if(find(data, 'H', start, end) != -1) leds |= 128;
-			output_leds(leds);
+			fputc(leds, output_leds);
 
 			//read switch values
 			//==================
-			switches = ~input_switches();
+			switches = ~fgetc(input_switches);
 			//find first ':'
 			index = find(page, ':', 0, 1460);
 			index+=2;
@@ -141,7 +160,7 @@ void user_design()
 
 			//read button values
 			//==================
-			buttons = ~input_buttons();
+			buttons = ~fgetc(input_buttons);
 			//find next ':'
 			index = find(page, ':', index+1, 1460);
 			index+=2;
@@ -165,6 +184,6 @@ void user_design()
 
 	}
 
-        //dummy access to peripherals
-	index = input_rs232_rx();
+    // dummy access to peripherals
+	index = fgetc(input_rs232_rx);
 }


### PR DESCRIPTION
Update to new Chips-2.0 format to handle input and output

;When creating a small ethernet frame, minimum size is now 60 bytes instead of 64, so CRC is added correctly.